### PR TITLE
package: only send relevant files to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "concat-stream": "^1.4.6",
     "tape": "^4.0.0"
   },
+  "files": [
+    "index.js"
+  ],
   "homepage": "https://github.com/feross/string-to-stream",
   "keywords": [
     "string to stream",


### PR DESCRIPTION
This will make npm ignore the `test/` folder when uploading the package. Saves space and bandwidth for all users :+1: 

This is especially important on embedded products like the Tessel where every byte counts.
