### PR TITLE
Fixes #6, adds optional 'encoding' parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ StringStream.prototype._read = function () {
   if (!this.ended) {
     var self = this
     process.nextTick(function () {
-      self.push(new Buffer(self._str, self._encoding))
+      self.push(Buffer.from(self._str, self._encoding))
       self.push(null)
     })
     this.ended = true

--- a/index.js
+++ b/index.js
@@ -5,17 +5,18 @@ var stream = require('readable-stream')
 
 inherits(StringStream, stream.Readable)
 
-function StringStream (str) {
-  if (!(this instanceof StringStream)) return new StringStream(str)
+function StringStream (str, encoding) {
+  if (!(this instanceof StringStream)) return new StringStream(str, encoding)
   stream.Readable.call(this)
   this._str = str
+  this._encoding = encoding || 'utf8'
 }
 
 StringStream.prototype._read = function () {
   if (!this.ended) {
     var self = this
     process.nextTick(function () {
-      self.push(new Buffer(self._str))
+      self.push(new Buffer(self._str, self._encoding))
       self.push(null)
     })
     this.ended = true


### PR DESCRIPTION
This allows StringStream to work with non-UTF8 encoded strings.